### PR TITLE
Security Fix for Prototype Pollution - huntr.dev

### DIFF
--- a/src/nestedObjectAssign.js
+++ b/src/nestedObjectAssign.js
@@ -9,7 +9,7 @@ export default function nestedObjectAssign(target, ...sources){
 
     if (isObject(target) && isObject(source)){
         for (const key in source){
-            if (isObject(source[key])){
+            if (isObject(source[key]) && !isPrototypePolluted(key)){
                 if (!target[key]) {
                     Object.assign(target, {[key]: {}});
                 }
@@ -28,4 +28,8 @@ export default function nestedObjectAssign(target, ...sources){
     }
 
     return nestedObjectAssign(target, ...sources);
+}
+
+function isPrototypePolluted(key){
+    return /__proto__|constructor|prototype/.test(key);
 }

--- a/test/nestedObjectAssign.spec.js
+++ b/test/nestedObjectAssign.spec.js
@@ -69,4 +69,10 @@ describe('Given an instance of nestedObjectAssign', function() {
             expect(JSON.stringify(nestedObjectAssign({}, mockData.default, mockData.first, mockData.second))).to.be.equal(JSON.stringify(expectedData));
         });
     });
+    describe('when I give malicious payload', function() {
+        it('it should not pollute object prototype', () => {
+            nestedObjectAssign({}, JSON.parse('{"__proto__": {"polluted": true}}'));
+            expect({}.polluted).to.be.equal(undefined);
+        });
+    });
 });


### PR DESCRIPTION
@arjunshibu (https://huntr.dev/users/arjunshibu) has fixed a potential Prototype Pollution vulnerability in your repository 🔨. For more information, visit our website (https://huntr.dev/) or click the bounty URL below...

Q | A
Version Affected | *
Bug Fix | YES
Original Pull Request | https://github.com/418sec/NestedObjectAssign/pull/1
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/nested-object-assign/1/README.md

### User Comments:

### :bar_chart: Metadata *

`nested-object-assign` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-nested-object-assign

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const assign = require('nested-object-assign')

console.log('Before: ' + {}.polluted)
assign({}, JSON.parse('{"__proto__": {"polluted": true}}'))
console.log('After: ' + {}.polluted)
```
2. Execute the following commands in terminal:
```bash
npm i nested-object-assign # Install vulnerable package
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: undefined
After: true
```

### :fire: Proof of Fix (PoF) *

*I've added unit tests for Prototype Pollution*

![image](https://user-images.githubusercontent.com/43996156/105441678-135ef100-5c8f-11eb-87ed-ce9a745f799e.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
